### PR TITLE
feat(deploy): pull Vercel token from 1Password instead of GitHub Secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,23 +39,31 @@ jobs:
       - name: Run e2e tests
         run: npm run test:e2e
 
+      - name: Load Vercel token from 1Password
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          VERCEL_TOKEN: op://${{ vars.VAULT_PROD }}/vercel-api-token/credential
+
       - name: Pull Vercel environment
         run: npx vercel@latest pull --yes --environment=production --token="${VERCEL_TOKEN}"
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TOKEN: ${{ env.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Build Vercel output
         run: npx vercel@latest build --prod --token="${VERCEL_TOKEN}"
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TOKEN: ${{ env.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Deploy to Vercel
         run: npx vercel@latest deploy --prebuilt --prod --token="${VERCEL_TOKEN}"
         env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TOKEN: ${{ env.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
## Summary

- Adds `1password/load-secrets-action` to pull `VERCEL_TOKEN` from `op://${{ vars.VAULT_PROD }}/vercel-api-token/credential` at deploy time
- Removes `VERCEL_TOKEN` from hardcoded GitHub Secrets references (`${{ secrets.VERCEL_TOKEN }}` → `${{ env.VERCEL_TOKEN }}`)
- `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` remain as GitHub Secrets (identifiers, not credentials)

## Prerequisites merged before this PR

- `OP_SERVICE_ACCOUNT_TOKEN` GitHub Secret
- `VAULT_PROD` GitHub Variable set to `MEG_CD_PROD`
- `vercel-api-token` item in MEG_CD_PROD 1Password vault
- Vercel Git integration disabled (GH Actions is the deploy path)