### PR TITLE
v0.1.0 fix: update Rio/OS docs link and team heading

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -49,7 +49,7 @@ const organizationJsonLd = {
     "https://github.com/megamsys",
     "https://github.com/rioos2",
     "https://docs.megam.io",
-    "https://docs.rioos.megam.io"
+    "https://rioos.megam.io"
   ],
   description:
     "Open-source cloud management platform (CMP) and platform-as-a-service (PaaS) built from Chennai, India. Active product development ended October 2018."
@@ -74,7 +74,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           </Link>
           <nav className="docs-nav" aria-label="Documentation links">
             <a href="https://docs.megam.io">Megam docs</a>
-            <a href="https://docs.rioos.megam.io">Rio/OS docs</a>
+            <a href="https://rioos.megam.io">Rio/OS docs</a>
           </nav>
         </header>
         <div className="shell">

--- a/content/artifacts.mdx
+++ b/content/artifacts.mdx
@@ -41,7 +41,7 @@ can differ.
 ## Docs
 
 - [Megam docs](https://docs.megam.io) - external Megam docs, linked rather than rehosted.
-- [Rio/OS docs](https://docs.rioos.megam.io) - external Rio/OS docs, linked rather than rehosted.
+- [Rio/OS docs](https://rioos.megam.io) - external Rio/OS docs, linked rather than rehosted.
 - [Developer center](https://devcenter.megam.io) - secondary Megam developer artifact.
 
 ## Talks and Videos

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -23,6 +23,6 @@ first-time visitor can understand what was built and why it changed.
 External docs:
 
 - [Megam docs](https://docs.megam.io)
-- [Rio/OS docs](https://docs.rioos.megam.io)
+- [Rio/OS docs](https://rioos.megam.io)
 
 Megam was early, not wrong.

--- a/content/team.mdx
+++ b/content/team.mdx
@@ -8,7 +8,7 @@ description: People associated with Megam, Rio/OS, and downstream successor proj
 Megam and Rio/OS were built by a small team in Chennai. A few later projects
 and partners continued the work in adjacent roles.
 
-## Megam / Rio/OS Team
+## Megam and Rio/OS Team
 
 ### Kishorekumar Neelamegam
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -32,7 +32,7 @@ Contact: nkishore@megam.io
 ## External docs
 
 - Megam docs: https://docs.megam.io
-- Rio/OS docs: https://docs.rioos.megam.io
+- Rio/OS docs: https://rioos.megam.io
 - Megam Systems on GitHub: https://github.com/megamsys
 - Rio/OS public source on GitHub: https://github.com/rioos2
 

--- a/tests/e2e/site.spec.ts
+++ b/tests/e2e/site.spec.ts
@@ -32,7 +32,7 @@ test.describe("closure site", () => {
     );
     await expect(header.getByRole("link", { name: "Rio/OS docs" })).toHaveAttribute(
       "href",
-      "https://docs.rioos.megam.io"
+      "https://rioos.megam.io"
     );
     await expect(page.getByRole("link", { name: /timeline/i }).first()).toHaveAttribute(
       "href",
@@ -51,7 +51,7 @@ test.describe("closure site", () => {
   test("team separates downstream projects", async ({ page }) => {
     await page.goto("/team");
 
-    await expect(page.getByRole("heading", { name: "Megam / Rio/OS Team" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Megam and Rio/OS Team" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Downstream / Successor Projects" })).toBeVisible();
     await expect(page.getByText("downstream commercial integrator activity")).toBeVisible();
   });


### PR DESCRIPTION
## Summary
- update public Rio/OS documentation links from `docs.rioos.megam.io` to `rioos.megam.io`
- rename the team section heading so Megam and Rio/OS read as separate names
- refresh the Playwright assertions that cover the docs link and team heading

## Verification
- `npm run lint`
- `npm run build`
- `npm run test:e2e` (58 passed)

## Notes
- no schema, API, or routing behavior changed
- this is a copy and external-link fix only
