### PR TITLE
feat(home): label archive list and emphasize still-building band

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -320,11 +320,12 @@ a:focus-visible {
 }
 
 .still-building {
-  margin: 8px 0 32px;
+  margin: 8px 0 40px;
   padding: 18px 20px;
+  border-left: 2px solid var(--accent-primary);
   border-top: 1px solid var(--rule-faint);
   border-bottom: 1px solid var(--rule-faint);
-  background: rgba(0, 229, 255, 0.025);
+  background: rgba(0, 229, 255, 0.04);
 }
 
 .still-building-eyebrow {

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -13,6 +13,8 @@ first-time visitor can understand what was built and why it changed.
 
 STILL_BUILDING_BAND
 
+The record:
+
 - [Timeline](/timeline)
 - [Architecture](/architecture)
 - [Products](/products)


### PR DESCRIPTION
## Summary
- Adds a **The record:** eyebrow above the archive doc list on the home page so it reads as its own labeled section, mirroring the existing **External docs:** label below.
- Strengthens the **Still building** band visually: cyan left accent rule + slightly warmer background fill, so the band reads as a self-contained card rather than a header bleeding into whatever follows.

## Why
The Still Building band's accent-cyan links sat directly above the unlabeled archive list (`/timeline`, `/architecture`, …). Visually, the band's "active" framing implied everything after it was still active too. Labeling the second list explicitly + giving the band stronger card identity collapses that ambiguity.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `gitleaks dir --config .gitleaks.toml --redact .`
- [ ] Visual check on `/` — band reads as a contained card, "The record:" labels the archive list

🤖 Generated with [Claude Code](https://claude.com/claude-code)