### PR TITLE
chore(e2e): run Playwright against the production build, not next dev

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,10 +3,15 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./tests/e2e",
   timeout: 30_000,
+  // Tests run against the production build (`next start`), not `next dev`.
+  // The site is fully static/SSG, so dev-mode on-demand compilation only adds
+  // slow, variable first-hit latency. Run `npm run build` before `test:e2e`
+  // (the canonical local/CI order); the server here just serves that build.
   webServer: {
-    command: "npm run dev",
+    command: "npm run start",
     url: "http://127.0.0.1:3000",
-    reuseExistingServer: !process.env.CI
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000
   },
   use: {
     baseURL: "http://127.0.0.1:3000",


### PR DESCRIPTION
## Problem

`lint → build → test:e2e` ran long and could appear to hang. Root cause: `playwright.config.ts` started its test server with **`next dev`**. Dev mode compiles each route lazily on first request, so all 9 routes paid a cold Turbopack compile mid-test (×2 device projects) — slow and variable. With no `webServer.timeout` set, a slow dev cold-start could exceed Playwright's default 60s and look like a hang.

The site is **100% static/SSG** (every route prerendered), so dev mode bought nothing but latency.

## Fix

- e2e test server is now **`npm run start`** — serves the production build, no on-demand compilation, deterministic runs.
- Uses `next start` (not `build && start`) so the **build isn't run twice** in the canonical `lint && build && test:e2e` sequence.
- Added `timeout: 120_000` so a slow start fails clearly instead of hanging at 60s.

Run order: `npm run build` then `npm run test:e2e`. `reuseExistingServer` still lets you keep a prod server running locally for fast iteration.

## Measured (local, M-series)

| stage | time |
|---|---|
| lint | ~2s |
| build | ~13s |
| e2e | **~19.6s** (was 32–38s on dev + hang risk) |

All **58 e2e tests pass** against the production server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)